### PR TITLE
feat: Add Gemini API connector and fix Docker ARM64 compatibility

### DIFF
--- a/crates/connectors/src/lib.rs
+++ b/crates/connectors/src/lib.rs
@@ -16,6 +16,7 @@ pub use providers::{
     daily::{Daily, DailyConfig},
     deepgram::{Deepgram, DeepgramConfig},
     elevenlabs::{ElevenLabs, ElevenLabsConfig},
+    gemini::{Gemini, GeminiConfig},
     openai::{OpenAI, OpenAIConfig},
     twilio::{twilio_transport_connector, TwilioConfig, TwilioTransportConnector},
 };

--- a/crates/connectors/src/providers/gemini.rs
+++ b/crates/connectors/src/providers/gemini.rs
@@ -1,0 +1,223 @@
+use crate::llm::{ChatMessage, LlmConnector, LlmRequest, LlmResponse, MessageRole, TokenUsage};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use serde_json::json;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+#[derive(Debug, Clone)]
+pub struct GeminiConfig {
+    pub api_key: String,
+    pub base_url: String,
+    pub default_llm_model: String,
+}
+
+impl GeminiConfig {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            api_key,
+            base_url: "https://generativelanguage.googleapis.com/v1beta".to_string(),
+            default_llm_model: "gemini-pro".to_string(),
+        }
+    }
+
+    pub fn with_base_url(mut self, base_url: String) -> Self {
+        self.base_url = base_url;
+        self
+    }
+
+    pub fn with_llm_model(mut self, model: String) -> Self {
+        self.default_llm_model = model;
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GeminiLlmConnector {
+    config: GeminiConfig,
+    client: reqwest::Client,
+}
+
+impl GeminiLlmConnector {
+    pub fn new(config: GeminiConfig) -> Self {
+        Self {
+            config,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    fn convert_messages(&self, messages: &[ChatMessage]) -> Vec<serde_json::Value> {
+        messages
+            .iter()
+            .map(|msg| {
+                // Gemini uses "user" and "model" roles, and "parts" with "text" content
+                let role = match msg.role {
+                    MessageRole::System => "user", // Gemini doesn't have system role, we'll prepend it
+                    MessageRole::User => "user",
+                    MessageRole::Assistant => "model",
+                };
+                json!({
+                    "role": role,
+                    "parts": [{
+                        "text": msg.content
+                    }]
+                })
+            })
+            .collect()
+    }
+}
+
+#[async_trait]
+impl LlmConnector for GeminiLlmConnector {
+    fn provider_name(&self) -> &'static str {
+        "gemini"
+    }
+
+    async fn health_check(&self) -> Result<bool> {
+        // Check if we can list models
+        let response = self
+            .client
+            .get(&format!("{}/models?key={}", self.config.base_url, self.config.api_key))
+            .send()
+            .await?;
+
+        Ok(response.status().is_success())
+    }
+
+    async fn generate(&self, request: LlmRequest) -> Result<LlmResponse> {
+        let start_time = Instant::now();
+
+        let model = request
+            .model
+            .unwrap_or_else(|| self.config.default_llm_model.clone());
+        
+        let mut contents = self.convert_messages(&request.messages);
+
+        // Handle system prompt - Gemini doesn't support system role directly,
+        // so we prepend it as a user message
+        if let Some(system_prompt) = request.system_prompt {
+            contents.insert(0, json!({
+                "role": "user",
+                "parts": [{
+                    "text": system_prompt
+                }]
+            }));
+        }
+
+        let mut payload = json!({
+            "contents": contents,
+        });
+
+        // Gemini uses generationConfig for parameters
+        let mut generation_config = json!({});
+        
+        if let Some(temp) = request.temperature {
+            generation_config["temperature"] = json!(temp);
+        }
+        if let Some(max_tokens) = request.max_tokens {
+            generation_config["maxOutputTokens"] = json!(max_tokens);
+        }
+
+        if !generation_config.as_object().unwrap().is_empty() {
+            payload["generationConfig"] = generation_config;
+        }
+
+        // Add any additional options
+        for (key, value) in request.options {
+            payload[key] = value;
+        }
+
+        let url = format!(
+            "{}/models/{}:generateContent?key={}",
+            self.config.base_url,
+            model,
+            self.config.api_key
+        );
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .json(&payload)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let error_text = response.text().await?;
+            return Err(anyhow!("Gemini API error: {}", error_text));
+        }
+
+        let response_json: serde_json::Value = response.json().await?;
+
+        // Extract text from Gemini response format
+        let text = response_json["candidates"][0]["content"]["parts"][0]["text"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Invalid response format from Gemini"))?
+            .to_string();
+
+        // Extract token usage if available
+        let usage_info = response_json["usageMetadata"].clone();
+        let token_usage = TokenUsage {
+            prompt_tokens: usage_info["promptTokenCount"]
+                .as_u64()
+                .unwrap_or(0) as u32,
+            completion_tokens: usage_info["candidatesTokenCount"]
+                .as_u64()
+                .unwrap_or(0) as u32,
+            total_tokens: usage_info["totalTokenCount"]
+                .as_u64()
+                .unwrap_or(0) as u32,
+        };
+
+        let processing_time = start_time.elapsed().as_millis() as u64;
+
+        let mut provider_metadata = HashMap::new();
+        provider_metadata.insert("raw_response".to_string(), response_json);
+
+        Ok(LlmResponse {
+            text,
+            model_used: model,
+            usage: token_usage,
+            processing_time_ms: processing_time,
+            provider_metadata,
+        })
+    }
+
+    async fn available_models(&self) -> Result<Vec<String>> {
+        let response = self
+            .client
+            .get(&format!("{}/models?key={}", self.config.base_url, self.config.api_key))
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(anyhow!("Failed to fetch models from Gemini"));
+        }
+
+        let models_json: serde_json::Value = response.json().await?;
+        let models = models_json["models"]
+            .as_array()
+            .ok_or_else(|| anyhow!("Invalid models response format"))?
+            .iter()
+            .filter_map(|model| {
+                let name = model["name"].as_str()?;
+                // Extract model name from full path like "models/gemini-pro"
+                name.strip_prefix("models/").map(|s| s.to_string())
+            })
+            .collect();
+
+        Ok(models)
+    }
+}
+
+/// Factory functions for Gemini connectors
+pub struct Gemini;
+
+impl Gemini {
+    /// Create Gemini LLM connector
+    pub fn llm_connector(config: GeminiConfig) -> Arc<dyn LlmConnector> {
+        Arc::new(GeminiLlmConnector::new(config))
+    }
+}
+

--- a/crates/connectors/src/providers/mod.rs
+++ b/crates/connectors/src/providers/mod.rs
@@ -1,5 +1,6 @@
 pub mod daily;
 pub mod deepgram;
 pub mod elevenlabs;
+pub mod gemini;
 pub mod openai;
 pub mod twilio;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,6 +42,10 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - OPENAI_BASE_URL=${OPENAI_BASE_URL:-https://api.openai.com/v1}
       - DEFAULT_MODEL=${DEFAULT_MODEL:-gpt-4}
+      # Google Gemini (Optional)
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - GEMINI_BASE_URL=${GEMINI_BASE_URL:-}
+      - GEMINI_MODEL=${GEMINI_MODEL:-gemini-pro}
     depends_on:
       nats:
         condition: service_healthy

--- a/services/meshag-service/src/llm.rs
+++ b/services/meshag-service/src/llm.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use meshag_connectors::{OpenAI, OpenAIConfig};
+use meshag_connectors::{Gemini, GeminiConfig, OpenAI, OpenAIConfig};
 use meshag_service_common::server;
 use meshag_services_llm::{LlmService, LlmServiceState, MultiSessionLlmService};
 use meshag_shared::{EventQueue, StreamConfig};
@@ -26,6 +26,21 @@ pub async fn run_llm_service() -> Result<()> {
             .register_connector("openai", openai_connector)
             .await;
         info!("Registered OpenAI connector");
+    }
+
+    if let Ok(api_key) = std::env::var("GEMINI_API_KEY") {
+        let mut config = GeminiConfig::new(api_key);
+        if let Ok(base_url) = std::env::var("GEMINI_BASE_URL") {
+            config = config.with_base_url(base_url);
+        }
+        if let Ok(model) = std::env::var("GEMINI_MODEL") {
+            config = config.with_llm_model(model);
+        }
+        let gemini_connector = Gemini::llm_connector(config);
+        llm_service
+            .register_connector("gemini", gemini_connector)
+            .await;
+        info!("Registered Gemini connector");
     }
 
     let multi_session = MultiSessionLlmService::new(llm_service.clone());


### PR DESCRIPTION
- Add Gemini LLM connector with full API support
  - Implement GeminiConfig and GeminiLlmConnector
  - Support for Gemini API message format and token usage
  - Automatic registration in LLM service when GEMINI_API_KEY is set
  - Configurable base URL and model selection

- Fix Docker image compatibility for Apple Silicon (ARM64)
  - Update all service Dockerfiles to build from rustlang/rust:nightly-bookworm
  - Remove dependency on external base image that lacks ARM64 support
  - Enable local builds for stt-service, llm-service, tts-service, transport-service

- Update docker-compose.yml
  - Add GEMINI_API_KEY, GEMINI_BASE_URL, GEMINI_MODEL environment variables
  - Change transport-service port mapping from 8084:8084 to 8080:8084 for ngrok compatibility

- Update connectors module exports
  - Export Gemini and GeminiConfig from connectors library
  - Add gemini module to providers